### PR TITLE
Filter out outlinks that being with a # (fragment or hash URL)

### DIFF
--- a/internal/pkg/crawl/outlinks.go
+++ b/internal/pkg/crawl/outlinks.go
@@ -17,6 +17,9 @@ func extractOutlinks(base *url.URL, doc *goquery.Document) (outlinks []url.URL, 
 	doc.Find("a").Each(func(index int, item *goquery.Selection) {
 		link, exists := item.Attr("href")
 		if exists {
+			if strings.HasPrefix(link, "#") {
+				return
+			}
 			rawOutlinks = append(rawOutlinks, link)
 		}
 	})

--- a/internal/pkg/crawl/outlinks.go
+++ b/internal/pkg/crawl/outlinks.go
@@ -17,6 +17,7 @@ func extractOutlinks(base *url.URL, doc *goquery.Document) (outlinks []url.URL, 
 	doc.Find("a").Each(func(index int, item *goquery.Selection) {
 		link, exists := item.Attr("href")
 		if exists {
+			// Hash (or fragment) URLs are navigational links pointing to the exact same page as such, they should not be treated as new outlinks.
 			if strings.HasPrefix(link, "#") {
 				return
 			}


### PR DESCRIPTION
Fragment or hash URLs almost always end up on the exact same page, especially ones without a full URL.

URLs like: "#main" or "#content" would be filtered out.

Important note: this won't filter out outlinks that contain fragment URLs if they are full URLs. (Maybe stripping out the fragments to allow proper seenchecking could make more sense in a future PR?)