### PR TITLE
fix: Properly remove fragments entirely from outlinks.

### DIFF
--- a/internal/pkg/crawl/outlinks.go
+++ b/internal/pkg/crawl/outlinks.go
@@ -17,10 +17,6 @@ func extractOutlinks(base *url.URL, doc *goquery.Document) (outlinks []url.URL, 
 	doc.Find("a").Each(func(index int, item *goquery.Selection) {
 		link, exists := item.Attr("href")
 		if exists {
-			// Hash (or fragment) URLs are navigational links pointing to the exact same page as such, they should not be treated as new outlinks.
-			if strings.HasPrefix(link, "#") {
-				return
-			}
 			rawOutlinks = append(rawOutlinks, link)
 		}
 	})
@@ -42,6 +38,9 @@ func extractOutlinks(base *url.URL, doc *goquery.Document) (outlinks []url.URL, 
 
 	// Go over all outlinks and make sure they are absolute links
 	outlinks = utils.MakeAbsolute(base, outlinks)
+
+	// Hash (or fragment) URLs are navigational links pointing to the exact same page as such, they should not be treated as new outlinks.
+	outlinks = utils.RemoveFragments(outlinks)
 
 	return utils.DedupeURLs(outlinks), nil
 }

--- a/internal/pkg/utils/url.go
+++ b/internal/pkg/utils/url.go
@@ -19,6 +19,14 @@ func MakeAbsolute(base *url.URL, URLs []url.URL) []url.URL {
 	return URLs
 }
 
+func RemoveFragments(URLs []url.URL) []url.URL {
+	for i := range URLs {
+		URLs[i].Fragment = ""
+	}
+
+	return URLs
+}
+
 // DedupeURLs take a slice of *url.URL and dedupe it
 func DedupeURLs(URLs []url.URL) []url.URL {
 	keys := make(map[string]bool)


### PR DESCRIPTION
This entirely wipes out the "fragment" section from URLs, effectively removing them entirely from the outlinks. These are unwanted.