### PR TITLE
Fix retry on non-proxied connections

### DIFF
--- a/internal/pkg/crawl/outlinks.go
+++ b/internal/pkg/crawl/outlinks.go
@@ -17,10 +17,6 @@ func extractOutlinks(base *url.URL, doc *goquery.Document) (outlinks []url.URL, 
 	doc.Find("a").Each(func(index int, item *goquery.Selection) {
 		link, exists := item.Attr("href")
 		if exists {
-			// Hash (or fragment) URLs are navigational links pointing to the exact same page as such, they should not be treated as new outlinks.
-			if strings.HasPrefix(link, "#") {
-				return
-			}
 			rawOutlinks = append(rawOutlinks, link)
 		}
 	})
@@ -42,6 +38,9 @@ func extractOutlinks(base *url.URL, doc *goquery.Document) (outlinks []url.URL, 
 
 	// Go over all outlinks and make sure they are absolute links
 	outlinks = utils.MakeAbsolute(base, outlinks)
+
+	// Hash (or fragment) URLs are navigational links pointing to the exact same page as such, they should not be treated as new outlinks.
+	outlinks = utils.RemoveFragments(outlinks)
 
 	return utils.DedupeURLs(outlinks), nil
 }

--- a/internal/pkg/utils/url.go
+++ b/internal/pkg/utils/url.go
@@ -19,6 +19,14 @@ func MakeAbsolute(base *url.URL, URLs []url.URL) []url.URL {
 	return URLs
 }
 
+func RemoveFragments(URLs []url.URL) []url.URL {
+	for i := range URLs {
+		URLs[i].Fragment = ""
+	}
+
+	return URLs
+}
+
 // DedupeURLs take a slice of *url.URL and dedupe it
 func DedupeURLs(URLs []url.URL) []url.URL {
 	keys := make(map[string]bool)


### PR DESCRIPTION
Before, when the connection was not proxied, they weren't getting retried. This is the exact opposite of the expected behavior. With this change, we respect the MaxRetry and retry correctly to the limit while sending better logging messages than before. 



(Somewhat addresses #16 but I don't think this is exactly what I was looking into)
(I think this _might_ have a commit from another branch as well, my apologies.)