### PR TITLE
Fix: potential SIGSEV when grabbing new base value from the base HTML tag

### DIFF
--- a/internal/pkg/crawl/capture.go
+++ b/internal/pkg/crawl/capture.go
@@ -295,15 +295,24 @@ func (c *Crawl) Capture(item *frontier.Item) {
 	// This checks for the "base" tag and resets the "base" URL variable with the new base URL specified
 	// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 	if !utils.StringInSlice("base", c.DisabledHTMLTags) {
+		oldBase := base
+
 		doc.Find("base").Each(func(index int, goitem *goquery.Selection) {
+			// If a new base got scraped, stop looking for one
+			if oldBase != base {
+				return
+			}
+
+			// Attempt to get a new base value from the base HTML tag
 			link, exists := goitem.Attr("href")
 			if exists {
-				base, err = url.Parse(link)
+				baseTagValue, err := url.Parse(link)
 				if err != nil {
 					logWarning.WithFields(logrus.Fields{
 						"error": err,
 					}).Warning(item.URL.String())
-					return
+				} else {
+					base = baseTagValue
 				}
 			}
 		})

--- a/internal/pkg/utils/url.go
+++ b/internal/pkg/utils/url.go
@@ -11,7 +11,7 @@ import (
 // on a given base *url.URL
 func MakeAbsolute(base *url.URL, URLs []url.URL) []url.URL {
 	for i, URL := range URLs {
-		if URL.IsAbs() == false {
+		if !URL.IsAbs() {
 			URLs[i] = *base.ResolveReference(&URL)
 		}
 	}


### PR DESCRIPTION
We got this error multiple times:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x63232b]

goroutine 82 [running]:
net/url.(*URL).ResolveReference(0x0, 0xc017ab3090, 0xc003b7ab70)
        /home/corentin/.go/src/net/url/url.go:1077 +0x8b
github.com/CorentinB/Zeno/internal/pkg/utils.MakeAbsolute(0x0, 0xc000319200, 0xc, 0x10, 0x0, 0x0, 0x0)
        /1/crawling/certificate-transparency/Zeno/internal/pkg/utils/url.go:15 +0xe5
github.com/CorentinB/Zeno/internal/pkg/crawl.extractOutlinks(0x0, 0xc010fd04b0, 0xc003b7a750, 0xc003b7a750, 0x0, 0x0, 0xc02f12ec00)
        /1/crawling/certificate-transparency/Zeno/internal/pkg/crawl/outlinks.go:40 +0x26c
github.com/CorentinB/Zeno/internal/pkg/crawl.(*Crawl).Capture(0xc0001f2300, 0xc02f12ec00)
        /1/crawling/certificate-transparency/Zeno/internal/pkg/crawl/capture.go:313 +0xa5c
github.com/CorentinB/Zeno/internal/pkg/crawl.(*Crawl).Worker(0xc0001f2300)
        /1/crawling/certificate-transparency/Zeno/internal/pkg/crawl/worker.go:41 +0x12e
created by github.com/CorentinB/Zeno/internal/pkg/crawl.(*Crawl).Start
        /1/crawling/certificate-transparency/Zeno/internal/pkg/crawl/crawl.go:197 +0x65c
```

It happens when MakeAbsolute is trying to make an url.URL absolute using a nil base url.URL. I **think** this might come from the <base> HTML tag parsing, when we try to get it and that it fails to parse the value detected.