### PR TITLE
Update warc to 0.8.8

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -164,6 +164,12 @@ var GlobalFlags = []cli.Flag{
 		Destination: &config.App.Flags.DisableLocalDedupe,
 	},
 	&cli.BoolFlag{
+		Name:        "enable-cert-validation",
+		Usage:       "Enables certificate validation on HTTPS requests",
+		Value:       false,
+		Destination: &config.App.Flags.EnableCertValidation,
+	},
+	&cli.BoolFlag{
 		Name:        "disable-assets-capture",
 		Usage:       "Disable assets capture",
 		Value:       false,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -164,10 +164,10 @@ var GlobalFlags = []cli.Flag{
 		Destination: &config.App.Flags.DisableLocalDedupe,
 	},
 	&cli.BoolFlag{
-		Name:        "enable-cert-validation",
+		Name:        "cert-validation",
 		Usage:       "Enables certificate validation on HTTPS requests",
 		Value:       false,
-		Destination: &config.App.Flags.EnableCertValidation,
+		Destination: &config.App.Flags.CertValidation,
 	},
 	&cli.BoolFlag{
 		Name:        "disable-assets-capture",

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -59,7 +59,7 @@ func InitCrawlWithCMD(flags config.Flags) *crawl.Crawl {
 	c.WARCOperator = flags.WARCOperator
 	c.CDXDedupeServer = flags.CDXDedupeServer
 	c.DisableLocalDedupe = flags.DisableLocalDedupe
-	c.EnableCertValidation = flags.EnableCertValidation
+	c.CertValidation = flags.CertValidation
 
 	c.API = flags.API
 	c.APIPort = flags.APIPort

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -59,6 +59,7 @@ func InitCrawlWithCMD(flags config.Flags) *crawl.Crawl {
 	c.WARCOperator = flags.WARCOperator
 	c.CDXDedupeServer = flags.CDXDedupeServer
 	c.DisableLocalDedupe = flags.DisableLocalDedupe
+	c.EnableCertValidation = flags.EnableCertValidation
 
 	c.API = flags.API
 	c.APIPort = flags.APIPort

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type Flags struct {
 	CDXDedupeServer      string
 	DisableLocalDedupe   bool
 	DisableAssetsCapture bool
+	EnableCertValidation bool
 }
 
 type Application struct {

--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,7 @@ type Flags struct {
 	CDXDedupeServer      string
 	DisableLocalDedupe   bool
 	DisableAssetsCapture bool
-	EnableCertValidation bool
+	CertValidation bool
 }
 
 type Application struct {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	git.archive.org/wb/gocrawlhq v1.1.9
-	github.com/CorentinB/warc v0.8.7
+	github.com/CorentinB/warc v0.8.8
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef
 	github.com/beeker1121/goque v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 git.archive.org/wb/gocrawlhq v1.1.9 h1:XLjRshzNsZZKP0nIoN3zs0xwef5s/y/Ngu6Qzn1BVEg=
 git.archive.org/wb/gocrawlhq v1.1.9/go.mod h1:IR7ynAW8FJH2N/MP99Vk3Fkf/Y1RgqJWAP/kK3VGStY=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/CorentinB/warc v0.8.6 h1:M/t/6h+ImHT5jcIXukpRqn4tvNIlnemWNAntGjO59GA=
-github.com/CorentinB/warc v0.8.6/go.mod h1:6Bo1vH18iD4qOSIY0ng8k00nT5HOOGAoEzdebaETBsE=
-github.com/CorentinB/warc v0.8.7 h1:4BX++OYU/9qyY8EK7cNOVoJznZ1V/Te4CQ+NfziXFqQ=
-github.com/CorentinB/warc v0.8.7/go.mod h1:6Bo1vH18iD4qOSIY0ng8k00nT5HOOGAoEzdebaETBsE=
+github.com/CorentinB/warc v0.8.8 h1:4GV49b7HT3glpti554GhT3IslKC3Ckfq1uWhHK48Wtc=
+github.com/CorentinB/warc v0.8.8/go.mod h1:6Bo1vH18iD4qOSIY0ng8k00nT5HOOGAoEzdebaETBsE=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0gta/U=
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=

--- a/internal/pkg/crawl/crawl.go
+++ b/internal/pkg/crawl/crawl.go
@@ -82,12 +82,13 @@ type Crawl struct {
 	CrawledAssets *ratecounter.Counter
 
 	// WARC settings
-	WARCPrefix         string
-	WARCOperator       string
-	WARCWriter         chan *warc.RecordBatch
-	WARCWriterFinish   chan bool
-	CDXDedupeServer    string
-	DisableLocalDedupe bool
+	WARCPrefix           string
+	WARCOperator         string
+	WARCWriter           chan *warc.RecordBatch
+	WARCWriterFinish     chan bool
+	CDXDedupeServer      string
+	DisableLocalDedupe   bool
+	EnableCertValidation bool
 
 	// crawl HQ settings
 	UseHQ             bool
@@ -151,7 +152,7 @@ func (c *Crawl) Start() (err error) {
 	errChan := make(chan error)
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	c.Client, err, errChan = warc.NewWARCWritingHTTPClient(rotatorSettings, "", true, dedupeOptions, []int{429})
+	c.Client, err, errChan = warc.NewWARCWritingHTTPClient(rotatorSettings, "", true, dedupeOptions, []int{429}, c.EnableCertValidation)
 	if err != nil {
 		logrus.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -164,7 +165,7 @@ func (c *Crawl) Start() (err error) {
 
 	if c.Proxy != "" {
 		errChanProxy := make(chan error)
-		c.ClientProxied, err, errChanProxy = warc.NewWARCWritingHTTPClient(rotatorSettings, c.Proxy, true, dedupeOptions, []int{429})
+		c.ClientProxied, err, errChanProxy = warc.NewWARCWritingHTTPClient(rotatorSettings, c.Proxy, true, dedupeOptions, []int{429}, c.EnableCertValidation)
 		if err != nil {
 			logrus.Fatalf("Unable to init WARC writing (proxy) HTTP client: %s", err)
 		}

--- a/internal/pkg/crawl/crawl.go
+++ b/internal/pkg/crawl/crawl.go
@@ -82,13 +82,13 @@ type Crawl struct {
 	CrawledAssets *ratecounter.Counter
 
 	// WARC settings
-	WARCPrefix           string
-	WARCOperator         string
-	WARCWriter           chan *warc.RecordBatch
-	WARCWriterFinish     chan bool
-	CDXDedupeServer      string
-	DisableLocalDedupe   bool
-	EnableCertValidation bool
+	WARCPrefix         string
+	WARCOperator       string
+	WARCWriter         chan *warc.RecordBatch
+	WARCWriterFinish   chan bool
+	CDXDedupeServer    string
+	DisableLocalDedupe bool
+	CertValidation     bool
 
 	// crawl HQ settings
 	UseHQ             bool
@@ -152,7 +152,7 @@ func (c *Crawl) Start() (err error) {
 	errChan := make(chan error)
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
-	c.Client, err, errChan = warc.NewWARCWritingHTTPClient(rotatorSettings, "", true, dedupeOptions, []int{429}, c.EnableCertValidation)
+	c.Client, err, errChan = warc.NewWARCWritingHTTPClient(rotatorSettings, "", true, dedupeOptions, []int{429}, c.CertValidation)
 	if err != nil {
 		logrus.Fatalf("Unable to init WARC writing HTTP client: %s", err)
 	}
@@ -165,7 +165,7 @@ func (c *Crawl) Start() (err error) {
 
 	if c.Proxy != "" {
 		errChanProxy := make(chan error)
-		c.ClientProxied, err, errChanProxy = warc.NewWARCWritingHTTPClient(rotatorSettings, c.Proxy, true, dedupeOptions, []int{429}, c.EnableCertValidation)
+		c.ClientProxied, err, errChanProxy = warc.NewWARCWritingHTTPClient(rotatorSettings, c.Proxy, true, dedupeOptions, []int{429}, c.CertValidation)
 		if err != nil {
 			logrus.Fatalf("Unable to init WARC writing (proxy) HTTP client: %s", err)
 		}


### PR DESCRIPTION
Add toggle for validating HTTPS certificates. By default this is set to "off" and we aren't validating certificates. Adding "--enable-cert-validation" will enable the functionality. 

Fixes #24 