### PR TITLE
Fix: properly extract CSS url() parameters.

### DIFF
--- a/internal/pkg/crawl/assets.go
+++ b/internal/pkg/crawl/assets.go
@@ -42,7 +42,12 @@ func (c *Crawl) extractAssets(base *url.URL, item *frontier.Item, doc *goquery.D
 				match_replacement := matches[match][1]
 				match_replacement = strings.Replace(match_replacement, "'", "", -1)
 				match_replacement = strings.Replace(match_replacement, "\"", "", -1)
-				match_replacement = strings.Replace(match_replacement, "//", "http://", -1)
+
+				// If the URL already has http (or https), we don't need add anything to it.
+				if !strings.Contains(match_replacement, "http") {
+					match_replacement = strings.Replace(match_replacement, "//", "http://", -1)
+				}
+
 				rawAssets = append(rawAssets, match_replacement)
 			}
 		})


### PR DESCRIPTION
Previously we weren't extracting urls properly from the CSS parameter of url(). This change, as far as I'm aware, doesn't have any issues and is exactly the behavior we are looking for.