### PR TITLE
Add real version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 jobs/*
+Zeno

--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -2,4 +2,5 @@ package all
 
 import (
 	_ "github.com/CorentinB/Zeno/cmd/get"
+	_ "github.com/CorentinB/Zeno/cmd/version"
 )

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -25,7 +25,7 @@ func init() {
 	cmd.RegisterCommand(
 		cli.Command{
 			Name:  "get",
-			Usage: "All commands that get URLs",
+			Usage: "Archive the web!",
 			Subcommands: []*cli.Command{
 				newGetURLCmd(),
 				newGetListCmd(),

--- a/cmd/get/hq.go
+++ b/cmd/get/hq.go
@@ -11,7 +11,7 @@ import (
 func newGetHQCmd() *cli.Command {
 	return &cli.Command{
 		Name:      "hq",
-		Usage:     "Start crawling with the crawl HQ connector",
+		Usage:     "Start crawling with the crawl HQ connector.",
 		Action:    cmdGetHQ,
 		Flags:     []cli.Flag{},
 		UsageText: "<FILE> [ARGUMENTS]",

--- a/cmd/get/list.go
+++ b/cmd/get/list.go
@@ -12,7 +12,7 @@ import (
 func newGetListCmd() *cli.Command {
 	return &cli.Command{
 		Name:      "list",
-		Usage:     "Start crawling with a seed list",
+		Usage:     "Start crawling with a seed list.",
 		Action:    cmdGetList,
 		Flags:     []cli.Flag{},
 		UsageText: "<FILE> [ARGUMENTS]",

--- a/cmd/get/url.go
+++ b/cmd/get/url.go
@@ -14,7 +14,7 @@ import (
 func newGetURLCmd() *cli.Command {
 	return &cli.Command{
 		Name:      "url",
-		Usage:     "Start crawling with a single URL",
+		Usage:     "Start crawling with a single URL.",
 		Action:    cmdGetURL,
 		Flags:     []cli.Flag{},
 		UsageText: "<URL> [ARGUMENTS]",

--- a/cmd/version/deps.go
+++ b/cmd/version/deps.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/urfave/cli/v2"
+)
+
+func newShowDepsCmd() *cli.Command {
+	return &cli.Command{
+		Name:   "deps",
+		Usage:  "Get dependencies.",
+		Action: cmdShowDeps,
+	}
+}
+
+func cmdShowDeps(c *cli.Context) error {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			fmt.Printf("%s %s (%s)", dep.Path, dep.Version, dep.Sum)
+			if dep.Replace != nil {
+				fmt.Printf(" => %s %s (%s)", dep.Replace.Path, dep.Replace.Version, dep.Replace.Sum)
+			} else {
+				fmt.Print("\n")
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,28 @@
+package version
+
+import (
+	"github.com/CorentinB/Zeno/cmd"
+	"github.com/CorentinB/Zeno/internal/pkg/utils"
+	"github.com/urfave/cli/v2"
+)
+
+func init() {
+	cmd.RegisterCommand(
+		cli.Command{
+			Name:   "version",
+			Usage:  "Show the version number.",
+			Action: cmdVersion,
+			Subcommands: []*cli.Command{
+				newShowDepsCmd(),
+			},
+		})
+}
+
+func cmdVersion(c *cli.Context) error {
+	version := utils.GetVersion()
+
+	println("Zeno", version.Version)
+	println("- go/version:", version.GoVersion)
+
+	return nil
+}

--- a/internal/pkg/crawl/crawl.go
+++ b/internal/pkg/crawl/crawl.go
@@ -2,7 +2,6 @@ package crawl
 
 import (
 	"net/http"
-	"os"
 	"path"
 	"sync"
 	"time"
@@ -134,18 +133,14 @@ func (c *Crawl) Start() (err error) {
 	// Initialize WARC writer
 	logrus.Info("Initializing WARC writer..")
 
-	// init WARC rotator settings
+	// Init WARC rotator settings
 	rotatorSettings := c.initWARCRotatorSettings()
 
-	// create the directory in which temporary files will be stored
-	// and start the temp files cleaner process
-	os.MkdirAll(path.Join(c.JobPath, "temp"), os.ModePerm)
-	go c.tempFilesCleaner()
 	dedupeOptions := warc.DedupeOptions{LocalDedupe: !c.DisableLocalDedupe}
-
 	if c.CDXDedupeServer != "" {
 		dedupeOptions = warc.DedupeOptions{LocalDedupe: !c.DisableLocalDedupe, CDXDedupe: true, CDXURL: c.CDXDedupeServer}
 	}
+
 	errChan := make(chan error)
 
 	// init the HTTP client responsible for recording HTTP(s) requests / responses
@@ -180,7 +175,7 @@ func (c *Crawl) Start() (err error) {
 		go c.startAPI()
 	}
 
-	// parse input cookie file if specified
+	// Parse input cookie file if specified
 	if c.CookieFile != "" {
 		cookieJar, err := cookiejar.NewFileJar(c.CookieFile, nil)
 		if err != nil {

--- a/internal/pkg/crawl/crawl.go
+++ b/internal/pkg/crawl/crawl.go
@@ -112,9 +112,6 @@ func (c *Crawl) Start() (err error) {
 	// Setup logging
 	logInfo, logWarning = utils.SetupLogging(c.JobPath, c.LiveStats)
 
-	// Initialize HTTP client
-	// c.initHTTPClient()
-
 	// Start the background process that will handle os signals
 	// to exit Zeno, like CTRL+C
 	go c.setupCloseHandler()

--- a/internal/pkg/crawl/utils.go
+++ b/internal/pkg/crawl/utils.go
@@ -1,11 +1,8 @@
 package crawl
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
-	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -71,25 +68,5 @@ func (crawl *Crawl) handleCrawlPause() {
 		}
 
 		time.Sleep(time.Second)
-	}
-}
-
-func (crawl *Crawl) tempFilesCleaner() {
-	for {
-		files, err := ioutil.ReadDir(path.Join(crawl.JobPath, "temp"))
-		if err != nil {
-			logrus.Fatal(err)
-		}
-
-		for _, file := range files {
-			if strings.HasSuffix(file.Name(), ".done") {
-				err := os.Remove(path.Join(crawl.JobPath, "temp", file.Name()))
-				if err != nil {
-					logrus.Fatal(err)
-				}
-			}
-		}
-
-		time.Sleep(time.Second * 1)
 	}
 }

--- a/internal/pkg/crawl/warc.go
+++ b/internal/pkg/crawl/warc.go
@@ -1,8 +1,10 @@
 package crawl
 
 import (
+	"fmt"
 	"path"
 
+	"github.com/CorentinB/Zeno/internal/pkg/utils"
 	"github.com/CorentinB/warc"
 )
 
@@ -36,7 +38,7 @@ func (c *Crawl) initWARCRotatorSettings() *warc.RotatorSettings {
 	rotatorSettings.OutputDirectory = path.Join(c.JobPath, "warcs")
 	rotatorSettings.Compression = "GZIP"
 	rotatorSettings.Prefix = c.WARCPrefix
-	rotatorSettings.WarcinfoContent.Set("software", "Zeno")
+	rotatorSettings.WarcinfoContent.Set("software", fmt.Sprintf("Zeno %s", utils.GetVersion()))
 	if len(c.WARCOperator) > 0 {
 		rotatorSettings.WarcinfoContent.Set("operator", c.WARCOperator)
 	}

--- a/internal/pkg/crawl/warc.go
+++ b/internal/pkg/crawl/warc.go
@@ -8,37 +8,14 @@ import (
 	"github.com/CorentinB/warc"
 )
 
-// dumpResponseToFile is like httputil.DumpResponse but dumps the response directly
-// to a file and return its path
-/*func (c *Crawl) dumpResponseToFile(resp *http.Response) (string, error) {
-	var err error
-
-	// Generate a file on disk with a unique name
-	UUID := uuid.NewV4()
-	filePath := filepath.Join(c.JobPath, "temp", UUID.String()+".temp")
-	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	// Write the response to the file directly
-	err = resp.Write(file)
-	if err != nil {
-		os.Remove(filePath)
-		return "", err
-	}
-
-	return filePath, nil
-}*/
-
 func (c *Crawl) initWARCRotatorSettings() *warc.RotatorSettings {
 	var rotatorSettings = warc.NewRotatorSettings()
 
 	rotatorSettings.OutputDirectory = path.Join(c.JobPath, "warcs")
 	rotatorSettings.Compression = "GZIP"
 	rotatorSettings.Prefix = c.WARCPrefix
-	rotatorSettings.WarcinfoContent.Set("software", fmt.Sprintf("Zeno %s", utils.GetVersion()))
+	rotatorSettings.WarcinfoContent.Set("software", fmt.Sprintf("Zeno %s", utils.GetVersion().Version))
+
 	if len(c.WARCOperator) > 0 {
 		rotatorSettings.WarcinfoContent.Set("operator", c.WARCOperator)
 	}

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime/debug"
 	"time"
 
 	rotatelogs "github.com/lestrrat-go/file-rotatelogs"
@@ -53,4 +54,25 @@ func SetupLogging(jobPath string, liveStats bool) (logInfo, logWarning *logrus.L
 	}
 
 	return logInfo, logWarning
+}
+
+// Defaults to "master" in case there is an error, else it returns the git hash with "-true" if the git tree on build was different
+func GetVersion() string {
+	version := "master"
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			// This returns the current git hash
+			if setting.Key == "vcs.revision" {
+				version = setting.Value
+			}
+
+			// This would show us if the current git tree is modified from the hash, possible changes that weren't committed.
+			if setting.Key == "vcs.modified" {
+				if setting.Value != "false" {
+					version = version + "-" + setting.Value
+				}
+			}
+		}
+	}
+	return version
 }

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"runtime/debug"
 	"time"
 
 	rotatelogs "github.com/lestrrat-go/file-rotatelogs"
@@ -54,25 +53,4 @@ func SetupLogging(jobPath string, liveStats bool) (logInfo, logWarning *logrus.L
 	}
 
 	return logInfo, logWarning
-}
-
-// Defaults to "master" in case there is an error, else it returns the git hash with "-true" if the git tree on build was different
-func GetVersion() string {
-	version := "master"
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, setting := range info.Settings {
-			// This returns the current git hash
-			if setting.Key == "vcs.revision" {
-				version = setting.Value
-			}
-
-			// This would show us if the current git tree is modified from the hash, possible changes that weren't committed.
-			if setting.Key == "vcs.modified" {
-				if setting.Value != "false" {
-					version = version + "-" + setting.Value
-				}
-			}
-		}
-	}
-	return version
 }

--- a/internal/pkg/utils/version.go
+++ b/internal/pkg/utils/version.go
@@ -1,0 +1,35 @@
+package utils
+
+import "runtime/debug"
+
+type Version struct {
+	Version   string
+	GoVersion string
+}
+
+func GetVersion() (version Version) {
+	// Defaults to master
+	version.Version = "master"
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		// Determine Zeno's version based on Git data
+		for _, setting := range info.Settings {
+			// This returns the current git hash
+			if setting.Key == "vcs.revision" {
+				version.Version = setting.Value
+			}
+
+			// This would show us if the current git tree is modified from the hash, possible changes that weren't committed
+			if setting.Key == "vcs.modified" {
+				if setting.Value == "true" {
+					version.Version += " (modified)"
+				}
+			}
+		}
+
+		// Get the Go version used to build Zeno
+		version.GoVersion = info.GoVersion
+	}
+
+	return version
+}

--- a/main.go
+++ b/main.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 Corentin Barreau <corentin.barreau24@gmail.com>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package main
 
 import (
@@ -27,13 +12,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// Version - defined default version if it's not passed through flags during build
-var Version string = "master"
-
 func main() {
 	app := cli.NewApp()
 	app.Name = "Zeno"
-	app.Version = utils.GetVersion()
+	app.Version = utils.GetVersion().Version
 	app.Authors = append(app.Authors, &cli.Author{Name: "Corentin Barreau", Email: "corentin@archive.org"})
 	app.Usage = ""
 
@@ -43,6 +25,7 @@ func main() {
 	app.Before = func(context *cli.Context) error {
 		return nil
 	}
+
 	app.After = func(context *cli.Context) error {
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/CorentinB/Zeno/cmd"
 	_ "github.com/CorentinB/Zeno/cmd/all"
+	"github.com/CorentinB/Zeno/internal/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -32,7 +33,7 @@ var Version string = "master"
 func main() {
 	app := cli.NewApp()
 	app.Name = "Zeno"
-	app.Version = Version
+	app.Version = utils.GetVersion()
 	app.Authors = append(app.Authors, &cli.Author{Name: "Corentin Barreau", Email: "corentin@archive.org"})
 	app.Usage = ""
 


### PR DESCRIPTION
Adds commit hash to warcinfo record, this is currently returning the entire hash, maybe we should return the first 7 characters like GitHub, which retains enough information to figure out exactly what code was writing to WARC? 

In warcinfo:
Current commit: `software: Zeno ae02086213b09b0a85388321596a99a1995e6ce2-true`
Previously: `software: Zeno`
Proposed additional, possible, change: `software: Zeno ae02086-true`
(and if nothing was modified in the local git tree: `software: Zeno ae02086`)